### PR TITLE
Make register and sign-in links overridable

### DIFF
--- a/lms/templates/login-sidebar.html
+++ b/lms/templates/login-sidebar.html
@@ -1,5 +1,5 @@
-<%! 
-from django.utils.translation import ugettext as _ 
+<%!
+from django.utils.translation import ugettext as _
 from django.core.urlresolvers import reverse
 %>
 
@@ -7,24 +7,26 @@ from django.core.urlresolvers import reverse
   <h2 class="sr">${_("Helpful Information")}</h2>
 </header>
 
-% if settings.FEATURES.get('AUTH_USE_OPENID'):
-<!-- <div class="cta cta-login-options-openid">
-  <h3>${_("Login via OpenID")}</h3>
-  <p>${_('You can now start learning with {platform_name} by logging in with your <a rel="external" href="http://openid.net/">OpenID account</a>.').format(platform_name=platform_name)}</p>
-  <a class="action action-login-openid" href="#">${_("Login via OpenID")}</a>
-</div> -->
-% endif
-
-<div class="cta cta-help">
-  <h3>${_("Not Enrolled?")}</h3>
-  <p><a href="${reverse('register_user')}">${_("Sign up for {platform_name} today!").format(platform_name=platform_name)}</a></p>
-
-  ## Disable help unless the FAQ marketing link is enabled
-  % if settings.MKTG_URL_LINK_MAP.get('FAQ'):
-    <h3>${_("Need Help?")}</h3>
-    <p>${_("Looking for help in logging in or with your {platform_name} account?").format(platform_name=platform_name)}
-    <a href="${marketing_link('FAQ')}">
-        ${_("View our help section for answers to commonly asked questions.")}
-    </a></p>
+<%block name="login_sidebar_content">
+  % if settings.FEATURES.get('AUTH_USE_OPENID'):
+  <!-- <div class="cta cta-login-options-openid">
+    <h3>${_("Login via OpenID")}</h3>
+    <p>${_('You can now start learning with {platform_name} by logging in with your <a rel="external" href="http://openid.net/">OpenID account</a>.').format(platform_name=platform_name)}</p>
+    <a class="action action-login-openid" href="#">${_("Login via OpenID")}</a>
+  </div> -->
   % endif
-</div>
+
+  <div class="cta cta-help">
+      <h3>${_("Not Enrolled?")}</h3>
+      <p><a href="${reverse('register_user')}">${_("Sign up for {platform_name} today!").format(platform_name=platform_name)}</a></p>
+
+      ## Disable help unless the FAQ marketing link is enabled
+      % if settings.MKTG_URL_LINK_MAP.get('FAQ'):
+        <h3>${_("Need Help?")}</h3>
+        <p>${_("Looking for help in logging in or with your {platform_name} account?").format(platform_name=platform_name)}
+        <a href="${marketing_link('FAQ')}">
+            ${_("View our help section for answers to commonly asked questions.")}
+        </a></p>
+      % endif
+  </div>
+</%block>

--- a/lms/templates/navigation.html
+++ b/lms/templates/navigation.html
@@ -123,30 +123,33 @@ site_status_msg = get_site_status_msg(course_id)
           </li>
         % endif
       </%block>
-      % if not settings.FEATURES['DISABLE_LOGIN_BUTTON']:
-          % if course and settings.FEATURES.get('RESTRICT_ENROLL_BY_REG_METHOD') and course.enrollment_domain:
-          <li class="nav-global-04">
-            <a class="cta cta-register" href="${reverse('course-specific-register', args=[course.id.to_deprecated_string()])}">${_("Register Now")}</a>
-          </li>
-          % else:
-          <li class="nav-global-04">
-            <a class="cta cta-register" href="/register${login_query()}">${_("Register Now")}</a>
-          </li>
-          % endif
-      % endif
+      <%block name="nav_global_register_link">
+        % if not settings.FEATURES['DISABLE_LOGIN_BUTTON']:
+            % if course and settings.FEATURES.get('RESTRICT_ENROLL_BY_REG_METHOD') and course.enrollment_domain:
+            <li class="nav-global-04">
+              <a class="cta cta-register" href="${reverse('course-specific-register', args=[course.id.to_deprecated_string()])}">${_("Register Now")}</a>
+            </li>
+            % else:
+            <li class="nav-global-04">
+              <a class="cta cta-register" href="/register${login_query()}">${_("Register Now")}</a>
+            </li>
+            % endif
+        % endif
+      </%block>
     </ol>
-
-    <ol class="right nav-courseware">
-    <li class="nav-courseware-01">
-      % if not settings.FEATURES['DISABLE_LOGIN_BUTTON']:
-          % if course and settings.FEATURES.get('RESTRICT_ENROLL_BY_REG_METHOD') and course.enrollment_domain:
-          <a class="cta cta-login" href="${reverse('course-specific-login', args=[course.id.to_deprecated_string()])}${login_query()}">${_("Sign in")}</a>
-          % else:
-          <a class="cta cta-login" href="/login${login_query()}">${_("Sign in")}</a>
-          % endif
-      % endif
-    </li>
-    </ol>
+    <%block name="nav_courseware">
+      <ol class="right nav-courseware">
+      <li class="nav-courseware-01">
+        % if not settings.FEATURES['DISABLE_LOGIN_BUTTON']:
+            % if course and settings.FEATURES.get('RESTRICT_ENROLL_BY_REG_METHOD') and course.enrollment_domain:
+            <a class="cta cta-login" href="${reverse('course-specific-login', args=[course.id.to_deprecated_string()])}${login_query()}">${_("Sign in")}</a>
+            % else:
+            <a class="cta cta-login" href="/login${login_query()}">${_("Sign in")}</a>
+            % endif
+        % endif
+      </li>
+      </ol>
+    </%block>
     % endif
   </nav>
 </header>


### PR DESCRIPTION
This wraps both, the register link and the right floating navigation
containing the Sign in link, in named blocks that can be overridden
in the theme templates.

This commit can be sent as a PR upstream.

The changes in https://github.com/enthought/edx-theme/pull/4 depend 
on changes here being merged first.

@agrawalprash : as with the above linked PR in edx-theme, may add 
a commit or two for further changes.
