### PR TITLE
Revert "Hide the homepage overlay."

### DIFF
--- a/lms/templates/index.html
+++ b/lms/templates/index.html
@@ -19,8 +19,13 @@ from microsite_configuration import microsite
 
 <section class="home">
   <header>
+    ## we wrap the following inside convenient named
+    ## blocks so that these can be easily overridden
+    ## in the theme if required.
+    <%block name='home_outer_wrapper'>
     <div class="outer-wrapper">
       <div class="title">
+      <%block name="home_header_title">
         <hgroup>
           % if homepage_overlay_html:
             ${homepage_overlay_html}
@@ -46,7 +51,7 @@ from microsite_configuration import microsite
             </form>
           </div>
         % endif
-
+      </%block> <!-- /home_header_title -->
       </div>
 
       % if show_homepage_promo_video:
@@ -57,6 +62,7 @@ from microsite_configuration import microsite
         </a>
       % endif
     </div>
+    </%block> <!-- /home_outer_wrapper -->
 
   </header>
   <section class="courses-container">

--- a/lms/templates/index.html
+++ b/lms/templates/index.html
@@ -19,7 +19,7 @@ from microsite_configuration import microsite
 
 <section class="home">
   <header>
-    <div class="outer-wrapper" style="display: none">
+    <div class="outer-wrapper">
       <div class="title">
         <hgroup>
           % if homepage_overlay_html:


### PR DESCRIPTION
This reverts commit 6d13b4cc22599e52b7c108b360b30a5d7957e083.

@agrawalprash 
This is how it looks now:

![image](https://cloud.githubusercontent.com/assets/94972/8730677/eaf6f5ba-2c0f-11e5-81e2-52c1f34e35ea.png)

We'd probably want to change the contents of this page as well while we're at it. But that should go into the edx-theme repo; so this commit just reverts the previous change.  
