### PR TITLE
Change email instructions to make them more clear for Enthought users.

### DIFF
--- a/openedx/core/djangoapps/user_api/views.py
+++ b/openedx/core/djangoapps/user_api/views.py
@@ -73,7 +73,13 @@ class LoginSessionView(APIView):
 
         # Translators: These instructions appear on the login form, immediately
         # below a field meant to hold the user's email address.
-        email_instructions = _("The email address you used to register with {platform_name}").format(
+        email_instructions = _(
+            "The email address you used to register with {platform_name}. "
+            "(Note: This login is separate from the main Enthought website "
+            "and Canopy login and you may have used a different username or "
+            "password to register here.  Thank you for your patience while we "
+            "work to integrate these systems)."
+        ).format(
             platform_name=settings.PLATFORM_NAME
         )
 


### PR DESCRIPTION
This is actually a hack, since we have to edit the common openedx code for
Enthought specific changes. However, this is because the openedx code is not
layered properly with improper separation of model and view.
